### PR TITLE
Support encoding option for request.

### DIFF
--- a/tasks/wget.js
+++ b/tasks/wget.js
@@ -30,11 +30,7 @@ module.exports = function (grunt) {
           return done();
         }
         log.verbose.writeln('Downloading', src.cyan, '->', dest.cyan);
-        var opts = { url: src };
-        if (options.encoding !== undefined) {
-          opts.encoding = options.encoding;
-        }
-        request(opts, function (err, res, body) {
+        request({ url: src, encoding: null }, function (err, res, body) {
           if (err) {
             done(err);
           } else if (res.statusCode >= 400) {


### PR DESCRIPTION
This gets around the binary file problem because request requires an
encoding of null in order to return binary data. See

https://github.com/mikeal/request#requestoptions-callback

This fixes #2 as long as you specify encoding: null in the options.
