### PR TITLE
ignore options + 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Default: `false`
 
 Whether to download the existing files. Set `true` to download the existing files.
 
+#### output
+
+Type: `Boolean`
+Default: `true`
+
+Whether to ignore downloaded file. Set to `false` to prevent to create a local file (useful if you want just to trigger remote urls).
+
 
 ## Usage Example
 
@@ -61,6 +68,17 @@ module.exports = function (grunt) {
           'jquery-1.11.0.min.js'
         ],
         dest: 'js/lib'
+      },
+
+      trigger: {
+        options: {
+          baseUrl: 'http://my.production.server/',
+          output: false
+        },
+        src: [
+          'deploy-master.do',
+          'deploy-develop.do',
+        }
       }
     }
   });

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "grunt-wget",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Wget plugin for Grunt.",
   "homepage": "https://github.com/shootaroo/grunt-wget",
-  "author": {
+  "author": [{
     "name": "shootaroo",
     "email": "shotaro.tsubouchi@gmail.com"
-  },
+  }, {
+    "name": "alberto-bottarini",
+    "email": "alberto.bottarini@gmail.com"
+  }],
   "repository": {
     "type": "git",
     "url": "git://github.com/shootaroo/grunt-wget.git"

--- a/tasks/wget.js
+++ b/tasks/wget.js
@@ -11,7 +11,8 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('wget', 'Download web contents.', function () {
 
     var options = this.options({
-      overwrite: false
+      overwrite: false,
+      output: true
     });
 
     var done = this.async();
@@ -25,8 +26,8 @@ module.exports = function (grunt) {
           src = options.baseUrl + src;
         }
         var srcUrl = url.parse(src);
-        var dest = isSingle ? filePair.dest : path.join(filePair.dest, srcUrl.pathname.split('/').pop());
-        if (!options.overwrite && grunt.file.exists(dest)) {
+        var dest = !options.output ? false : (isSingle ? filePair.dest : path.join(filePair.dest, srcUrl.pathname.split('/').pop()));
+        if (!options.overwrite && options.output && grunt.file.exists(dest)) {
           return done();
         }
         log.verbose.writeln('Downloading', src.cyan, '->', dest.cyan);
@@ -37,8 +38,10 @@ module.exports = function (grunt) {
             done(new Error(res.statusCode + ' ' + src));
           } else {
             count++;
-            grunt.file.mkdir(isSingle ? path.dirname(filePair.dest) : filePair.dest);
-            fs.writeFile(dest, body, done);
+            if(dest) {
+              grunt.file.mkdir(isSingle ? path.dirname(filePair.dest) : filePair.dest);
+              fs.writeFile(dest, body, done);
+            } else done();
           }
         });
       }, done);
@@ -47,7 +50,7 @@ module.exports = function (grunt) {
         grunt.fail.warn(err);
       }
       if (count) {
-        log.writeln('Downloaded', String(count).cyan, count === 1 ? 'file' : 'files');
+        log.writeln(options.output ? 'Downloaded' : 'Requested', String(count).cyan, count === 1 ? 'file' : 'files');
       }
       done();
     });


### PR DESCRIPTION
Hi.
I've updated your grunt-wget project adding a new options called `output`.
With this option (defaulted to true) you can control wget out and if you want wget results as local file. I'm using this features to trigger remote services (for example jenkins task...) directly from my working environment.

Let me know what you think about this.